### PR TITLE
Adding timezone per claude

### DIFF
--- a/events.ics
+++ b/events.ics
@@ -14,7 +14,7 @@ ORGANIZER;CN="Christchurch Ruby Team":MAILTO:christchurch@ruby.nz
 LOCATION:{{ event.location }}
 SUMMARY:[chch-ruby] {{ event.title | remove: ',' | remove: ';' }}
 CLASS:PUBLIC
-DTDURATION:PT2H
+DURATION:PT2H
 DTSTART;TZID=Pacific/Auckland:{{ event.date | date: "%Y%m%d" }}T{{ event.time | date: "%H%M%S" }}
 END:VEVENT
 {%- endfor %}
@@ -22,7 +22,7 @@ END:VEVENT
 BEGIN:VEVENT
 UID:future-meetups@christchurch.ruby.nz
 DTSTAMP:{{ site.time | date: "%Y%m%dT%H%M%S" }}
-DTDURATION:PT2H
+DURATION:PT2H
 DTSTART;TZID=Pacific/Auckland:{{ last_scheduled_event.date | date: "%Y%m%d" }}T193000
 RRULE:FREQ=MONTHLY;BYDAY=3TH
 SUMMARY:Christchurch Ruby Meetup

--- a/events.ics
+++ b/events.ics
@@ -14,16 +14,16 @@ ORGANIZER;CN="Christchurch Ruby Team":MAILTO:christchurch@ruby.nz
 LOCATION:{{ event.location }}
 SUMMARY:[chch-ruby] {{ event.title | remove: ',' | remove: ';' }}
 CLASS:PUBLIC
-DTSTART:{{ event.date | date: "%Y%m%d" }}T{{ event.time | date: "%H%M%S" }}
 DTDURATION:PT2H
+DTSTART;TZID=Pacific/Auckland:{{ event.date | date: "%Y%m%d" }}T{{ event.time | date: "%H%M%S" }}
 END:VEVENT
 {%- endfor %}
 {%- assign last_scheduled_event = recent_events | first %}
 BEGIN:VEVENT
 UID:future-meetups@christchurch.ruby.nz
 DTSTAMP:{{ site.time | date: "%Y%m%dT%H%M%S" }}
-DTSTART:{{ last_scheduled_event.date | date: "%Y%m%d" }}T193000
 DTDURATION:PT2H
+DTSTART;TZID=Pacific/Auckland:{{ last_scheduled_event.date | date: "%Y%m%d" }}T193000
 RRULE:FREQ=MONTHLY;BYDAY=3TH
 SUMMARY:Christchurch Ruby Meetup
 DESCRIPTION:Monthly meetup. Details TBA. Time and location are typical\, but may change for a specific meetup


### PR DESCRIPTION
Google calendar is assuming the dates are UTC, so it appears like it's happening at 07:30 on Friday.

<img width="163" height="145" alt="Screenshot 2026-05-14 at 9 34 52 PM" src="https://github.com/user-attachments/assets/3315ee05-24eb-44c5-973f-f5936be66c9c" />


----------claude tells me this -------------

https://christchurch.ruby.nz/events.ics why is google calendar displaying this feed as 07:30 on the Friday when it should be 7:30pm the day before.  I assume timezone offsets

9:37 PM
Claude responded: Let me fetch that ICS file to look at how the events are encoded.
Let me fetch that ICS file to look at how the events are encoded.


Fetched: https://christchurch.ruby.nz/events.ics
Fetched: https://christchurch.ruby.nz/events.ics
That confirms exactly what you suspected. The problem is the DTSTART values like:

DTSTART:20260521T193000
This is a "floating" datetime — there's no timezone specified. Per the iCalendar spec (RFC 5545), a datetime without a TZID parameter and without a trailing Z is interpreted as "local time" — but local to what? That's where it gets ambiguous.

Google Calendar, when it encounters a floating time with no timezone context anywhere in the file, tends to interpret it as UTC. So T193000 (19:30) in UTC becomes:

19:30 UTC = 07:30 NZST the next morning (UTC+12)
Or 08:30 NZDT during daylight saving (UTC+13)
That's your Friday 07:30 right there — Google is treating the Thursday 7:30pm as UTC, and shifting it forward to NZ time.

The fix is to either add a VTIMEZONE component and use TZID on each DTSTART, or append a timezone identifier directly. For example, changing:

DTSTART:20251218T193000
to:

DTSTART;TZID=Pacific/Auckland:20251218T193000
Alternatively, the feed could convert to explicit UTC with a Z suffix (e.g., DTSTART:20251218T063000Z for 19:30 NZDT), but using TZID=Pacific/Auckland is cleaner because it also handles the NZST/NZDT transitions automatically.

There's also a minor issue: the file uses DTDURATION which isn't a standard iCalendar property — it should be DURATION instead. Some parsers may ignore it silently.



--------------------

Completely untested though.